### PR TITLE
chore: call `ussd_after_callback/3` only on error

### DIFF
--- a/lib/ex_ussd/navigation.ex
+++ b/lib/ex_ussd/navigation.ex
@@ -89,7 +89,7 @@ defmodule ExUssd.Navigation do
         end
 
       position ->
-        with {_, current_menu} = menu <- get_menu(position, route, menu, payload),
+        with {:halt, current_menu} = menu <- get_menu(position, route, menu, payload),
              response when not is_menu(response) <-
                Executer.execute_after_callback(current_menu, payload) do
           menu


### PR DESCRIPTION
This PR ensures that `ussd_after_callback/3` only when menu returns an error